### PR TITLE
implement `build-url` and `build-url-short`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Produce the current timestamp to invalidate the previous version so every build 
  - "$BUILD_PIPELINE_NAME" > build-pipeline-name
  - "$BUILD_TEAM_NAME" > build-team-name
  - "$ATC_EXTERNAL_URL" > atc-external-url 
+ - "$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME" > build-url (this is a URL to the build)
+ - "$ATC_EXTERNAL_URL/builds/$BUILD_ID" > build-url-short (this is a shorter URL to the build)
 
 #### Parameters
 

--- a/in/in_test.go
+++ b/in/in_test.go
@@ -89,6 +89,8 @@ var _ = Describe("In", func() {
 			checkProp(destination, "build-pipeline-name", "BUILD_PIPELINE_NAME", "4", response.Metadata[3])
 			checkProp(destination, "build-team-name", "BUILD_TEAM_NAME", "5", response.Metadata[4])
 			checkProp(destination, "atc-external-url", "ATC_EXTERNAL_URL", "6", response.Metadata[5])
+			checkProp(destination, "build-url", "BUILD_URL", "6/teams/5/pipelines/4/jobs/3/builds/2", response.Metadata[6])
+			checkProp(destination, "build-url-short", "BUILD_URL_SHORT", "6/builds/1", response.Metadata[7])
 		})
 
 	})

--- a/in/main.go
+++ b/in/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -23,7 +24,7 @@ func main() {
 		fatal("creating destination", err)
 	}
 
-	meta := make(models.Metadata,6)
+	meta := make(models.Metadata,8)
 
 	var request models.InRequest
 
@@ -34,12 +35,26 @@ func main() {
 
 	var inVersion = request.Version
 
+	// pretend that Concourse set these metadata envvars (maybe it would be
+	// a good idea to implement them on the Concourse side?)
+	os.Setenv("BUILD_URL", fmt.Sprintf("%s/teams/%s/pipelines/%s/jobs/%s/builds/%s",
+		url.PathEscape(os.Getenv("ATC_EXTERNAL_URL")),
+		url.PathEscape(os.Getenv("BUILD_TEAM_NAME")),
+		url.PathEscape(os.Getenv("BUILD_PIPELINE_NAME")),
+		url.PathEscape(os.Getenv("BUILD_JOB_NAME")),
+		url.PathEscape(os.Getenv("BUILD_NAME"))))
+	os.Setenv("BUILD_URL_SHORT", fmt.Sprintf("%s/builds/%s",
+		url.PathEscape(os.Getenv("ATC_EXTERNAL_URL")),
+		url.PathEscape(os.Getenv("BUILD_ID"))))
+
 	handleProp(destination, "build-id", "BUILD_ID", meta, 0)
 	handleProp(destination, "build-name", "BUILD_NAME", meta, 1)
 	handleProp(destination, "build-job-name", "BUILD_JOB_NAME", meta, 2)
 	handleProp(destination, "build-pipeline-name", "BUILD_PIPELINE_NAME", meta, 3)
 	handleProp(destination, "build-team-name", "BUILD_TEAM_NAME", meta, 4)
 	handleProp(destination, "atc-external-url", "ATC_EXTERNAL_URL", meta, 5)
+	handleProp(destination, "build-url", "BUILD_URL", meta, 6)
+	handleProp(destination, "build-url-short", "BUILD_URL_SHORT", meta, 7)
 
 	json.NewEncoder(os.Stdout).Encode(models.InResponse{
 		Version:  inVersion,


### PR DESCRIPTION
One often uses the metadata envvars to construct a URL to the Concourse build page. This PR makes it easier - by moving the logic of that into this resource.